### PR TITLE
Function name is no longer a capture group

### DIFF
--- a/main.js
+++ b/main.js
@@ -130,7 +130,7 @@ define(function (require, exports, module) {
 
         // @TODO Make this actually work
         // Add the return line
-        if (func.return) {
+        if (func.returns) {
             output.push(' * @returns ' + wrapper[0] + '[[Type]]' + wrapper[1] + ' [[Description]]')
         }
 


### PR DESCRIPTION
Since we no longer care about the function name, I altered the regexp to not include it as a capture group
